### PR TITLE
Enable parallel builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,7 @@ libopx_nas_meta_packet_la_SOURCES=src/nas_packet_meta.c
 libopx_nas_meta_packet_la_LIBADD=-lopx_common -lopx_logging
 
 libopx_nas_packet_io_la_SOURCES=src/packet_io.c
-libopx_nas_packet_io_la_LIBADD=-lopx_common -lopx_logging -lopx_nas_interface -lopx_nas_meta_packet -lopx_nas_ndi -lopx_cps_api_common -lpthread
+libopx_nas_packet_io_la_LIBADD=-lopx_common -lopx_logging libopx_nas_interface.la libopx_nas_meta_packet.la -lopx_nas_ndi -lopx_cps_api_common -lpthread
 
 systemdconfdir=/lib/systemd/system
 systemdconf_DATA = scripts/init/*.service

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,5 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@  --with autoreconf,systemd
+	dh $@  --with autoreconf,systemd --parallel
 


### PR DESCRIPTION
This change adds --parallel flag to dh invocation in debian/rules and fixes target
dependencies in Makefile.am.

Signed-off-by: J.T. Conklin <jtc@acorntoolworks.com>