### PR TITLE
Revert "Removed unneeded dependcy on nas-platform"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ libopx_nas_interface_la_SOURCES=src/swp_util_tap.c src/nas_int_main.cpp \
          src/port/nas_int_breakout.cpp src/port/nas_int_physical_cps.cpp \
          src/stats/nas_stats_if_cps.cpp src/stats/nas_stats_vlan_cps.cpp \
          src/vlan/nas_vlan_lag_api.cpp
-libopx_nas_interface_la_LIBADD=-lopx_common -lopx_nas_common -lopx_nas_ndi -lopx_cps_api_common -lopx_logging -lopx_nas_linux -lpthread -levent
+libopx_nas_interface_la_LIBADD=-lopx_common -lopx_nas_common -lopx_nas_ndi -lopx_cps_api_common -lopx_logging -lopx_nas_linux -lopx_nas_platform -lpthread -levent
 
 libopx_nas_meta_packet_la_SOURCES=src/nas_packet_meta.c
 libopx_nas_meta_packet_la_LIBADD=-lopx_common -lopx_logging

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libopx-nas-interface
 Section: net
 Priority: optional
 Maintainer: Dell <support@dell.com>
-Build-Depends: debhelper (>= 9),dh-autoreconf,dh-systemd,autotools-dev,libevent-dev,libopx-common-dev,libopx-nas-common-dev,libopx-cps-dev,libopx-logging-dev,libopx-nas-linux-dev,libopx-nas-ndi-dev,opx-ndi-api-dev
+Build-Depends: debhelper (>= 9),dh-autoreconf,dh-systemd,autotools-dev,libevent-dev,libopx-common-dev,libopx-nas-common-dev,libopx-cps-dev,libopx-logging-dev,libopx-nas-linux-dev,libopx-nas-ndi-dev,opx-ndi-api-dev,libopx-nas-platform1
 Standards-Version: 3.9.3
 Vcs-Browser: https://github.com/open-switch/opx-nas-interface
 Vcs-Git: https://github.com/open-switch/opx-nas-interface.git


### PR DESCRIPTION
This reverts commit affe51f29c494ab5e39a6db9d4112f5bd2284df1.

libopx-nas-platform1 provides functions ndi_plat_vlan_stat_list_get(),
ndi_plat_port_stat_list_get(), and ndi_plat_git_ids_len() -- which are
used by libopx-nas-interface.