### PR TITLE
Feature and bugfixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-interface], [5.18.0], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-interface], [5.18.0+opx1], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+opx-nas-interface (5.18.0+opx1) unstable; urgency=medium
+  * Bugfix: Sending sequential hwport offset value from port group object to PAS
+            for setting media transciever
+  * Bugfix: Handle the mode change for lag blocked port in netlink handler
+  * Bugfix: Get the port mode before adding port to LAG in kernel
+  * Bugfix: Remove the publish of oper state just after connecting interface to NPU port
+  * Bugfix: Using steady clock for providing independent timestamps
+  * Bugfix: Fix MAC address change when adding memberport to LAG
+  * Feature: Add interface name and ifindex to the output list when querying for stats
+  * Feature: Adding QSA support for 1G SFP media
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 05 Jul 2018 17:17:56 -0800
+
 opx-nas-interface (5.18.0) unstable; urgency=medium
   
   * Update: VLAN interface-state get-handler
@@ -30,7 +42,7 @@ opx-nas-interface (5.10.1+opx15) unstable; urgency=medium
   * Bugfix: Fix error when configuring block and unblock LAG memberports in
             the same command.
 
- -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 26 Apr 2018 17:17:56 -0800
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 18 Jun 2018 17:17:56 -0800
 
 opx-nas-interface (5.10.1+opx14) unstable; urgency=medium
 

--- a/inc/opx/nas_int_vlan.h
+++ b/inc/opx/nas_int_vlan.h
@@ -132,7 +132,7 @@ cps_api_return_code_t nas_publish_vlan_object(nas_bridge_t *p_bridge_node, cps_a
 
 t_std_error nas_add_or_del_port_to_vlan(npu_id_t npu_id, hal_vlan_id_t vlan_id,
                                         ndi_port_t *p_ndi_port, nas_port_mode_t port_mode,
-                                        bool add_port);
+                                        bool add_port, hal_ifindex_t ifindex);
 
 t_std_error nas_cps_add_port_to_os(hal_ifindex_t br_index, hal_vlan_id_t vlan_id,
                                    nas_port_mode_t port_mode, hal_ifindex_t port_idx,uint32_t mtu,

--- a/scripts/bin/base_nas_front_panel_ports.py
+++ b/scripts/bin/base_nas_front_panel_ports.py
@@ -162,7 +162,7 @@ def _set_speed(speed, config, obj):
             return False
     config.set_speed(speed)
     if speed == _yang_auto_speed:
-        if intf_phy_mode == nas_comm.get_value(nas_comm.yang_phy_mode, 'fc') or breakout_mode == _yang_breakout_1x1 or breakout_mode == _yang_breakout_4x4:
+        if intf_phy_mode == nas_comm.get_value(nas_comm.yang_phy_mode, 'fc') or breakout_mode == _yang_breakout_1x1 or breakout_mode == _yang_breakout_4x4 or media.is_sfp_media_type(config.get_media_type()):
             # TODO default speed in breakout mode is not supported  yet
             # TODO it may cause issue in port group ports. Verify the usecases.
             _add_default_speed(config, obj)

--- a/scripts/bin/base_nas_monitor_phy_media.py
+++ b/scripts/bin/base_nas_monitor_phy_media.py
@@ -58,7 +58,12 @@ def set_media_transceiver(interface_obj):
     #
     for hwport in hwport_list:
         fp_details = fp.find_port_by_hwport(npu, hwport)
-        _lane = fp_details.lane
+        if fp_details.port_group_id is None:
+            _lane = fp_details.lane
+        else:
+            pg_list = fp.get_port_group_list()
+            pg_obj = pg_list[fp_details.port_group_id]
+            _lane = pg_obj.get_lane(hwport)
         media.media_transceiver_set(1, fp_details.media_id, _lane, enable)
 
 def set_interface_media_speed(interface_obj, speed=None):

--- a/scripts/bin/opx-show-transceivers
+++ b/scripts/bin/opx-show-transceivers
@@ -41,7 +41,6 @@ def display_media_inventory(verbose=False):
             # If port density > 1, use logical port list
             _port_density =  obj.get_attr_data('port-density')
             _sub_port_list = []
-            _qsa_str = ''
             if (_port_density > 0):
                 _sub_port_list = obj.get_attr_data('sub-port-id')
             else:
@@ -58,12 +57,7 @@ def display_media_inventory(verbose=False):
                 _serial_no = obj.get_attr_data('base-pas/media/serial-number')
                 _qualified = obj.get_attr_data('base-pas/media/qualified')
                 _disp_str_from_pas = obj.get_attr_data('base-pas/media/display-string')
-                _qsa_adap_type = obj.get_attr_data('base-pas/media/qsa-adapter')
 
-                if (_qsa_adap_type == PLATFORM_QSA_ADAPTER_QSA):
-                    _qsa_str = "(+QSA)"
-                elif (_qsa_adap_type == PLATFORM_QSA_ADAPTER_QSA28):
-                    _qsa_str = "(+QSA28)"
                 if (_disp_str_from_pas == ''):
                     _disp_str_from_pas = media.get_media_str(_media_type)
                 if _qualified == 1:
@@ -71,7 +65,7 @@ def display_media_inventory(verbose=False):
                 else:
                     _qualified = 'No'
             for _port in _sub_port_list:
-                print '%4s              %-30s%9s         %-18s    %-18s        %4s' % (str(_port), _disp_str_from_pas, _qsa_str, _vendor_pn, _serial_no, _qualified)
+                print '%4s              %-30s         %-18s    %-18s        %4s' % (str(_port), _disp_str_from_pas, _vendor_pn, _serial_no, _qualified)
             if verbose == True :
                 for _port in _sub_port_list:
                     display_media_info(_port)

--- a/scripts/lib/python/nas_front_panel_map.py
+++ b/scripts/lib/python/nas_front_panel_map.py
@@ -528,6 +528,7 @@ def find_port_by_hwport(npu, hwport):
     pd.port = p.id
     pd.hwport = hwport
     pd.media_id = p.media_id
+    pd.port_group_id = p.port_group_id
     return pd
 
 
@@ -619,6 +620,8 @@ class PortGroup(PortProfile):
         return self.fp_ports[:]
     def get_hw_ports(self):
         return self.hw_ports[:]
+    def get_lane(self,hwport):
+        return self.hw_ports.index(hwport)
 
     def apply_port_profile(self, port_profile):
         self.apply(port_profile)

--- a/scripts/lib/python/nas_phy_media.py
+++ b/scripts/lib/python/nas_phy_media.py
@@ -25,6 +25,29 @@ import bytearray_utils as ba
 
 _fp_port_key = cps.key_from_name('target','base-if-phy/front-panel-port')
 
+sfp_type_to_str = {
+    53: "SFP SX",
+    54: "SFP LX",
+    55: "SFP ZX",
+    56: "SFP CX",
+    57: "SFP DX",
+    58: "SFP T",
+    59: "SFP FX",
+    60: "SFP CWDM",
+    61: "SFP IR1",
+    62: "SFP LR1",
+    63: "SFP LR2",
+    64: "SFP BX10",
+    65: "SFP PX",
+    114: "SFP BX10 UP",
+    115: "SFP BX10 DOWN",
+    116: "SFP BX40 UP",
+    117: "SFP BX40 DOWN",
+    118: "SFP BX80 UP",
+    119: "SFP BX80 DOWN"
+}
+
+
 media_type_to_str = {
     0: "Not Applicable",
     1: "Not Present",
@@ -332,6 +355,12 @@ cps_utils.add_attr_type('base-pas/media/type', 'uint32_t')
 
 def is_qsfp28_media_type(media_type):
     if media_type in qsfp28_media_list:
+        return True
+    else:
+        return False
+
+def is_sfp_media_type(media_type):
+    if media_type in sfp_type_to_str:
         return True
     else:
         return False

--- a/src/nas_int_base_if.cpp
+++ b/src/nas_int_base_if.cpp
@@ -203,6 +203,12 @@ void nas_intf_container::nas_intf_dump_container(hal_ifindex_t ifx) noexcept {
 
 bool nas_intf_obj::nas_intf_obj_master_add(if_master_info_t m_info) {
 
+    for(auto itr = m_list.begin(); itr != m_list.end(); ++itr) {
+        if(itr->m_if_idx == m_info.m_if_idx) {
+            return false;
+        }
+    }
+
     //If LAG master, insert at front
     if(m_info.type == nas_int_type_LAG){
         m_list.push_front(m_info);

--- a/src/stats/nas_stats_if_cps.cpp
+++ b/src/stats/nas_stats_if_cps.cpp
@@ -41,6 +41,7 @@
 #include "ietf-interfaces.h"
 
 #include <time.h>
+#include <chrono>
 #include <vector>
 #include <unordered_map>
 #include <stdint.h>
@@ -158,6 +159,13 @@ static t_std_error populate_if_stat_ids(){
     return STD_ERR_OK;
 }
 
+static auto get_current_time() -> std::size_t{
+
+    auto time_stamp = std::chrono::steady_clock::now();
+    auto time_dur =  time_stamp.time_since_epoch();
+    auto time_now = time_dur.count() * std::chrono::system_clock::period::num / std::chrono::system_clock::period::den;
+    return time_now;
+}
 
 static bool get_stats(hal_ifindex_t ifindex, cps_api_object_list_t list){
 
@@ -195,7 +203,11 @@ static bool get_stats(hal_ifindex_t ifindex, cps_api_object_list_t list){
         cps_api_object_attr_add_u64(obj, if_stat_ids->at(ix), stat_values[ix]);
     }
 
-    cps_api_object_attr_add_u32(obj,DELL_BASE_IF_CMN_IF_INTERFACES_STATE_INTERFACE_STATISTICS_TIME_STAMP,time(NULL));
+    auto time_now = get_current_time();
+    cps_api_object_attr_add_u32(obj,DELL_BASE_IF_CMN_IF_INTERFACES_STATE_INTERFACE_STATISTICS_TIME_STAMP,time_now);
+    cps_api_object_attr_add_u32(obj,IF_INTERFACES_STATE_INTERFACE_IF_INDEX, ifindex);
+    if (strlen(intf_ctrl.if_name) != 0)
+        cps_api_object_attr_add(obj, IF_INTERFACES_STATE_INTERFACE_NAME, intf_ctrl.if_name, strlen(intf_ctrl.if_name) + 1);
 
     return true;
 }
@@ -219,8 +231,9 @@ static bool fill_cps_stats (cps_api_object_t obj, char *ptr, const char *name) {
     for(unsigned int ix = 0 ; ix < ARRAY_SIZE(stats_map) ; ++ix ){
        cps_api_object_attr_add_u64(obj, stats_map[ix].oid, stats_arr[stats_map[ix].index]);
     }
-    cps_api_object_attr_add_u32(obj,DELL_BASE_IF_CMN_IF_INTERFACES_STATE_INTERFACE_STATISTICS_TIME_STAMP,
-      time(NULL));
+
+    auto time_now =  get_current_time();
+    cps_api_object_attr_add_u32(obj,DELL_BASE_IF_CMN_IF_INTERFACES_STATE_INTERFACE_STATISTICS_TIME_STAMP,time_now);
     return ret;
 }
 

--- a/src/unit_test/nas_int_vlan_filter_unittest.cpp
+++ b/src/unit_test/nas_int_vlan_filter_unittest.cpp
@@ -59,7 +59,7 @@ static uint32_t get_vlan_filter_value (void)
 
     if (cps_api_get(&gp)==cps_api_ret_code_OK) {
         cps_api_object_t obj = cps_api_object_list_get(gp.list, 0);
-        cps_api_object_attr_t filter_attr = cps_api_get_key_data(obj, 
+        cps_api_object_attr_t filter_attr = cps_api_get_key_data(obj,
                 DELL_BASE_IF_CMN_IF_INTERFACES_STATE_INTERFACE_VLAN_FILTER);
         if (filter_attr == nullptr)
         {

--- a/src/unit_test/nas_port_pkt_drop_test.py
+++ b/src/unit_test/nas_port_pkt_drop_test.py
@@ -1,10 +1,13 @@
 import subprocess
-import pytest
 import cps
 import cps_object
 
 test_intf = 'e101-002-0'
 test_vlan_id = 100
+
+PORT_ACCEPT_UNTAGGED = 1
+PORT_ACCEPT_TAGGED = 2
+PORT_ACCEPT_BOTH = 3
 
 def run_command(cmd, response = None):
     prt = subprocess.Popen(
@@ -14,7 +17,7 @@ def run_command(cmd, response = None):
         stderr=subprocess.STDOUT)
     if response is not None:
         for line in prt.stdout.readlines():
-            respose.append(line.rstrip())
+            response.append(line.rstrip())
     retval = prt.wait()
     return retval
 
@@ -31,26 +34,48 @@ def get_intf_tagging_mode(if_name):
         mode = None
     return mode
 
-def test_packet_drop_status():
+def test_default_drop_status():
+    # get untagged members under default vlan
+    untagged_intf_list = None
+    resp = []
+    assert run_command('cps_config_vlan.py --show --name br1', resp) == 0
+    for ret_line in resp:
+        tokens = ret_line.split('=')
+        if len(tokens) < 2:
+            continue
+        if tokens[0].strip() == 'dell-if/if/interfaces/interface/untagged-ports':
+            untagged_intf_list = tokens[1].strip().split(',')
+            break
+    if untagged_intf_list is None:
+        print 'No untagged member for default VLAN'
+        return
+    for intf in untagged_intf_list:
+        print 'Testing default drop status for interface %s' % intf
+        assert get_intf_tagging_mode(intf) == PORT_ACCEPT_UNTAGGED
+
+def test_vlan_packet_drop_status():
+    print 'Testing drop status change for interface %s with VLAN %d' % (test_intf, test_vlan_id)
     # create vlan, delete port from default vlan 1 and add untagged port to new vlan
     assert run_command('cps_config_vlan.py --add --id %d --vlantype 1' % test_vlan_id) == 0
     assert run_command('cps_config_vlan.py --delport --name br1 --port %s' % test_intf) == 0
     assert run_command('cps_config_vlan.py --addport --name br%d --port %s' % (test_vlan_id, test_intf)) == 0
-    # no drop enabled
-    assert get_intf_tagging_mode(test_intf) == 3
+    # tagged packets will be dropped for untagged member port
+    assert get_intf_tagging_mode(test_intf) == PORT_ACCEPT_UNTAGGED
     # delete untagged port from vlan
     assert run_command('cps_config_vlan.py --delport --name br%d --port %s' % (test_vlan_id, test_intf)) == 0
-    # untagged drop should be enabled
-    assert get_intf_tagging_mode(test_intf) == 2
+    # if port is not member of any vlan, it will not drop any kind of packets
+    assert get_intf_tagging_mode(test_intf) == PORT_ACCEPT_BOTH
     # add tagged port to vlan
     assert run_command('cps_config_vlan.py --addport --name br%d -t --port %s' % (test_vlan_id, test_intf)) == 0
-    # untagged drop status should not change
-    assert get_intf_tagging_mode(test_intf) == 2
+    # untagged packets will be dropped for tagged member port
+    assert get_intf_tagging_mode(test_intf) == PORT_ACCEPT_TAGGED
     assert run_command('cps_config_vlan.py --delport --name br%d -t --port %s' % (test_vlan_id, test_intf)) == 0
-    assert get_intf_tagging_mode(test_intf) == 2
+    # port is removed from vlan as tagged member, it will not drop any kind of packets
+    assert get_intf_tagging_mode(test_intf) == PORT_ACCEPT_BOTH
     # add port back to default vlan 1
     assert run_command('cps_config_vlan.py --addport --name br1 --port %s' % test_intf) == 0
-    assert get_intf_tagging_mode(test_intf) == 3
+    # port is restored to default status
+    assert get_intf_tagging_mode(test_intf) == PORT_ACCEPT_UNTAGGED
 
     # delete vlan
     assert run_command('cps_config_vlan.py --del --name br%d' % test_vlan_id) == 0

--- a/src/vlan/nas_int_bridge.cpp
+++ b/src/vlan/nas_int_bridge.cpp
@@ -279,7 +279,8 @@ hal_vlan_id_t vid, nas_port_mode_t port_mode, bool lag) {
         } else {
             if (!nas_is_non_npu_phy_port(p_iter_node->ifindex)) {
                 if (nas_add_or_del_port_to_vlan(p_iter_node->ndi_port.npu_id, vid,
-                                    &(p_iter_node->ndi_port), port_mode, false) != STD_ERR_OK) {
+                                    &(p_iter_node->ndi_port), port_mode, false, p_iter_node->ifindex)
+                        != STD_ERR_OK) {
                     EV_LOGGING(INTERFACE, ERR, "NAS-Vlan",
                       "Error deleting port %d with mode %d from vlan %d", p_iter_node->ifindex,
                        port_mode, vid);

--- a/src/vlan/nas_int_vlan.cpp
+++ b/src/vlan/nas_int_vlan.cpp
@@ -41,6 +41,7 @@
 #include "hal_interface_common.h"
 #include "iana-if-type.h"
 #include "nas_if_utils.h"
+#include "nas_int_base_if.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -154,9 +155,40 @@ void nas_handle_bridge_mac(nas_bridge_t *b_node)
     nas_cps_set_vlan_mac(name_obj, b_node);
 }
 
+static std::pair<bool, bool> nas_get_intf_packet_drop(hal_ifindex_t ifindex)
+{
+    int untagged_cnt = 0, tagged_cnt = 0;
+    auto master_cb = [&untagged_cnt, &tagged_cnt](if_master_info_t m_info) {
+        if (m_info.type != nas_int_type_VLAN) {
+            return;
+        }
+        if (m_info.mode == NAS_PORT_UNTAGGED || m_info.mode == NAS_PORT_HYBRID) {
+            untagged_cnt ++;
+        }
+        if (m_info.mode == NAS_PORT_TAGGED || m_info.mode == NAS_PORT_HYBRID) {
+            tagged_cnt ++;
+        }
+    };
+    nas_intf_master_callback(ifindex, master_cb);
+    EV_LOGGING(INTERFACE, INFO, "NAS-Vlan", "Interface with ifindex %d is untagged member of %d bridges and \
+tagged member of %d bridges",
+               ifindex, untagged_cnt, tagged_cnt);
+    bool drop_untag = true, drop_tag = true;
+    if (untagged_cnt > 0) {
+        drop_untag = false;
+    }
+    if (tagged_cnt > 0) {
+        drop_tag = false;
+    }
+    if (untagged_cnt == 0 && tagged_cnt == 0) {
+        drop_untag = drop_tag = false;
+    }
+    return std::make_pair(drop_untag, drop_tag);
+}
+
 t_std_error nas_add_or_del_port_to_vlan(npu_id_t npu_id, hal_vlan_id_t vlan_id,
                                         ndi_port_t *p_ndi_port, nas_port_mode_t port_mode,
-                                        bool add_port)
+                                        bool add_port, hal_ifindex_t ifindex)
 {
     ndi_port_list_t ndi_port_list;
     ndi_port_list_t *untag_list = NULL;
@@ -197,17 +229,25 @@ t_std_error nas_add_or_del_port_to_vlan(npu_id_t npu_id, hal_vlan_id_t vlan_id,
                         npu_id, p_ndi_port->npu_port);
             }
         }
+    }
 
-        EV_LOGGING(INTERFACE, INFO, "NAS-Vlan",
-                   "Updating packet drop: %s port <%d %d> discard untagged packet",
-                   (!add_port ? "enable" : "disable"),
-                   p_ndi_port->npu_id, p_ndi_port->npu_port);
-        if ((rc = ndi_port_set_packet_drop(npu_id, p_ndi_port->npu_port,
-                                           NDI_PORT_DROP_UNTAGGED, !add_port)) != STD_ERR_OK) {
-            EV_LOGGING(INTERFACE, ERR, "NAS-Port",
-                       "Error setting untagged drop for port <%d %d>",
-                       npu_id, p_ndi_port->npu_port);
-        }
+    auto pkt_drop = nas_get_intf_packet_drop(ifindex);
+    EV_LOGGING(INTERFACE, INFO, "NAS-Vlan",
+               "Updating packet drop for port <%d %d>: untagged - %s; tagged - %s",
+               p_ndi_port->npu_id, p_ndi_port->npu_port,
+               pkt_drop.first ? "drop" : "not drop",
+               pkt_drop.second ? "drop" : "not drop");
+    if ((rc = ndi_port_set_packet_drop(npu_id, p_ndi_port->npu_port,
+                                       NDI_PORT_DROP_UNTAGGED, pkt_drop.first)) != STD_ERR_OK) {
+        EV_LOGGING(INTERFACE, ERR, "NAS-Port",
+                   "Error setting untagged drop for port <%d %d>",
+                   npu_id, p_ndi_port->npu_port);
+    }
+    if ((rc = ndi_port_set_packet_drop(npu_id, p_ndi_port->npu_port,
+                                       NDI_PORT_DROP_TAGGED, pkt_drop.second)) != STD_ERR_OK) {
+        EV_LOGGING(INTERFACE, ERR, "NAS-Port",
+                   "Error setting tagged drop for port <%d %d>",
+                   npu_id, p_ndi_port->npu_port);
     }
 
     ndi_intf_link_state_t link_state;
@@ -257,21 +297,45 @@ t_std_error nas_vlan_delete(npu_id_t npu_id, hal_vlan_id_t vlan_id)
 }
 
 static t_std_error nas_add_port_list_to_vlan(npu_id_t npu_id, hal_vlan_id_t vlan_id,
-                                               ndi_port_list_t *p_ndi_port_list,
-                                               bool tagged_port_list)
+                                const std::vector<std::pair<ndi_port_t, hal_ifindex_t>>& port_list,
+                                bool tagged_port_list)
 {
     t_std_error rc = STD_ERR_OK;
+    std::vector<ndi_port_t> tmp_port_list{};
+    for (auto& port_info: port_list) {
+        tmp_port_list.push_back(port_info.first);
+    }
+    ndi_port_list_t ndi_port_list{tmp_port_list.size(), tmp_port_list.data()};
     if (tagged_port_list) {
-        if ((rc = ndi_add_or_del_ports_to_vlan(npu_id, vlan_id,  p_ndi_port_list, NULL, true))
+        if ((rc = ndi_add_or_del_ports_to_vlan(npu_id, vlan_id,  &ndi_port_list, NULL, true))
                 != STD_ERR_OK)
             return rc;
     }
     else {
-        if ((rc = ndi_add_or_del_ports_to_vlan(npu_id, vlan_id, NULL, p_ndi_port_list, true))
+        if ((rc = ndi_add_or_del_ports_to_vlan(npu_id, vlan_id, NULL, &ndi_port_list, true))
              != STD_ERR_OK)
             return rc;
     }
-    return rc;
+    for (auto& port_info: port_list) {
+        npu_port_t port_id = port_info.first.npu_port;
+        auto pkt_drop = nas_get_intf_packet_drop(port_info.second);
+        EV_LOGGING(INTERFACE, INFO, "NAS-Port",
+                   "Updating packet drop for port <%d %d>: untagged - %s; tagged - %s",
+                   npu_id, port_id,
+                   pkt_drop.first ? "drop" : "not drop",
+                   pkt_drop.second ? "drop" : "not drop");
+        rc = ndi_port_set_packet_drop(npu_id, port_id, NDI_PORT_DROP_UNTAGGED, pkt_drop.first);
+        if (rc != STD_ERR_OK) {
+            EV_LOGGING(INTERFACE, INFO, "NAS-Port", "Failed to disable untagged drop for port <%d %d>",
+                       npu_id, port_id);
+        }
+        rc = ndi_port_set_packet_drop(npu_id, port_id, NDI_PORT_DROP_TAGGED, pkt_drop.second);
+        if (rc != STD_ERR_OK) {
+            EV_LOGGING(INTERFACE, INFO, "NAS-Port", "Failed to disable untagged drop for port <%d %d>",
+                       npu_id, port_id);
+        }
+    }
+    return STD_ERR_OK;
 }
 
 static t_std_error nas_vlan_get_intf_ctrl_info(hal_ifindex_t index, interface_ctrl_t &i){
@@ -291,18 +355,9 @@ static t_std_error nas_vlan_get_intf_ctrl_info(hal_ifindex_t index, interface_ct
 
 //@TODO change this to the vector..
 static void nas_copy_bridge_ports_to_ndi_port_list(std_dll_head *p_port_list,
-                                                   ndi_port_list_t *p_ndi_ports)
+                                    std::vector<std::pair<ndi_port_t, hal_ifindex_t>>& ndi_ports)
 {
     nas_list_node_t *p_link_iter_node = NULL, *p_temp_node = NULL;
-    ndi_port_t *p_port_t = NULL;
-    int count = 0;
-
-    if ((p_port_list == NULL) ||
-        (p_ndi_ports == NULL)) {
-        EV_LOGGING(INTERFACE, ERR, "NAS-Vlan",
-                   "Bridge port list or NDI port list is empty");
-        return;
-    }
 
     p_link_iter_node = nas_get_first_link_node(p_port_list);
 
@@ -311,10 +366,7 @@ static void nas_copy_bridge_ports_to_ndi_port_list(std_dll_head *p_port_list,
         EV_LOGGING(INTERFACE, DEBUG, "NAS-Vlan",
                     "Copying untagged port %d",
                      p_link_iter_node->ndi_port.npu_port);
-
-        p_port_t = &(p_ndi_ports->port_list[count++]);
-        p_port_t->npu_id = p_link_iter_node->ndi_port.npu_id;
-        p_port_t->npu_port = p_link_iter_node->ndi_port.npu_port;
+        ndi_ports.push_back(std::make_pair(p_link_iter_node->ndi_port, p_link_iter_node->ifindex));
 
         p_temp_node = p_link_iter_node;
         p_link_iter_node = nas_get_next_link_node(p_port_list, p_temp_node);
@@ -324,7 +376,6 @@ static void nas_copy_bridge_ports_to_ndi_port_list(std_dll_head *p_port_list,
 
 static t_std_error nas_add_all_ut_ports_to_vlan(nas_bridge_t *p_bridge_node)
 {
-    ndi_port_list_t ndi_port_list;
     size_t port_count = p_bridge_node->untagged_list.port_count;
     int npu_id = 0;
     nas_list_node_t *p_iter_node = NULL;
@@ -333,16 +384,13 @@ static t_std_error nas_add_all_ut_ports_to_vlan(nas_bridge_t *p_bridge_node)
 
     if (port_count != 0) {
         do {
-            ndi_port_list.port_list = (ndi_port_t *)malloc(sizeof (ndi_port_t) * port_count);
-            if (ndi_port_list.port_list==NULL) { err = STD_ERR(INTERFACE,FAIL,0) ; break; }
-
-            ndi_port_list.port_count = port_count;
+            std::vector<std::pair<ndi_port_t, hal_ifindex_t>> port_list{};
             nas_copy_bridge_ports_to_ndi_port_list(&p_bridge_node->untagged_list.port_list,
-                                                   &ndi_port_list);
+                                                   port_list);
 
             /* @todo : NPU_ID for bridge */
             if (nas_add_port_list_to_vlan(npu_id, p_bridge_node->vlan_id,
-                                      &ndi_port_list,
+                                      port_list,
                                       false) != STD_ERR_OK) {
                 err = (STD_ERR(INTERFACE,FAIL, 0));
                 break;
@@ -359,7 +407,6 @@ static t_std_error nas_add_all_ut_ports_to_vlan(nas_bridge_t *p_bridge_node)
             }
 
         } while(0);
-        free(ndi_port_list.port_list);
     }
     return err;
 }
@@ -427,7 +474,8 @@ t_std_error nas_process_list_for_vlan_del(nas_bridge_t *p_bridge,
                      p_link_node->ndi_port.npu_port);
 
         if (nas_add_or_del_port_to_vlan(p_link_node->ndi_port.npu_id, vlan_id,
-                                        &(p_link_node->ndi_port), port_mode, false) != STD_ERR_OK) {
+                                        &(p_link_node->ndi_port), port_mode, false, if_index)
+                != STD_ERR_OK) {
             EV_LOGGING(INTERFACE, ERR, "NAS-Vlan",
                         "Error deleting port %d from vlan %d",
                          if_index, vlan_id);
@@ -671,7 +719,8 @@ t_std_error nas_process_member_addition_to_vlan(nas_bridge_t *p_bridge_node, hal
         if(intf_type == nas_int_type_PORT) {
             //add tagged port to vlan
             if ((rc = nas_add_or_del_port_to_vlan(p_link_node->ndi_port.npu_id, p_bridge_node->vlan_id,
-                                                  &(p_link_node->ndi_port), port_mode, true)) != STD_ERR_OK) {
+                                                  &(p_link_node->ndi_port), port_mode, true, port_idx))
+                    != STD_ERR_OK) {
                 rc = (STD_ERR(INTERFACE,FAIL, rc));
                 return rc;
             }

--- a/src/vlan/nas_vlan_cps.cpp
+++ b/src/vlan/nas_vlan_cps.cpp
@@ -133,7 +133,7 @@ static bool nas_vlan_process_port_association(hal_ifindex_t ifindex, npu_id_t np
                 return false;
             }
 
-            if((nas_add_or_del_port_to_vlan(npu,br_m->vlan_id,&ndi_port, it.mode,add)) != STD_ERR_OK){
+            if((nas_add_or_del_port_to_vlan(npu,br_m->vlan_id,&ndi_port, it.mode, add, ifindex)) != STD_ERR_OK){
                 EV_LOGGING(INTERFACE, ERR, "NAS-VLAN-MAP","Error adding port <%d %d> to NPU",
                         ndi_port.npu_id, ndi_port.npu_port);
                 nas_bridge_unlock();
@@ -1281,7 +1281,7 @@ static t_std_error nas_cps_add_port_to_vlan(nas_bridge_t *p_bridge, hal_ifindex_
 
     if ((p_link_node != NULL) && (!nas_is_non_npu_phy_port(port_idx))) {
         if((rc = nas_add_or_del_port_to_vlan(p_link_node->ndi_port.npu_id, vlan_id,
-                                      &(p_link_node->ndi_port), port_mode, true)) != STD_ERR_OK) {
+                                      &(p_link_node->ndi_port), port_mode, true, port_idx)) != STD_ERR_OK) {
             EV_LOGGING(INTERFACE, ERR, "NAS-Vlan",
                    "Error adding port <%d %d> to NPU",
                    p_link_node->ndi_port.npu_id, p_link_node->ndi_port.npu_port);
@@ -1376,7 +1376,8 @@ static t_std_error nas_cps_del_port_from_vlan(nas_bridge_t *p_bridge, nas_list_n
     if (!nas_is_non_npu_phy_port(p_link_node->ifindex)) {
     //delete the port from NPU if it is a NPU port
         if (nas_add_or_del_port_to_vlan(p_link_node->ndi_port.npu_id, p_bridge->vlan_id,
-                                    &(p_link_node->ndi_port), port_mode, false) != STD_ERR_OK) {
+                                    &(p_link_node->ndi_port), port_mode, false, p_link_node->ifindex)
+                != STD_ERR_OK) {
             EV_LOGGING(INTERFACE, ERR, "NAS-Vlan",
                   "Error deleting port %d with mode %d from vlan %d", p_link_node->ifindex,
                    port_mode, p_bridge->vlan_id);


### PR DESCRIPTION
* Bugfix: Sending sequential hwport offset value from port group object to PAS
          for setting media transciever
* Bugfix: Handle the mode change for lag blocked port in netlink handler
* Bugfix: Get the port mode before adding port to LAG in kernel
* Bugfix: Remove the publish of oper state just after connecting interface to NPU port
* Bugfix: Using steady clock for providing independent timestamps
* Bugfix: Fix MAC address change when adding memberport to LAG
* Feature: Add interface name and ifindex to the output list when querying for stats
* Feature: Adding QSA support for 1G SFP media

Signed-off-by: Garrick He <garrick_he@dell.com>