### PR TITLE
LAG interface-state name filter

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-interface], [5.18.0+opx6], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-interface], [5.18.0+opx7], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+opx-nas-interface (5.18.0+opx7) unstable; urgency=medium
+
+  * Bugfix: Remove useless imported libraries from cps_config_lag.py
+  * Bugfix: Remove unneeded function definitions
+  * Bugfix: Fix LAG interface-state get-handler not honoring name-filters
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 13 Aug 2018 19:20:56 -0800
+
 opx-nas-interface (5.18.0+opx6) unstable; urgency=medium
 
   * Update: VRF get-handler support

--- a/inc/opx/nas_int_lag_api.h
+++ b/inc/opx/nas_int_lag_api.h
@@ -164,8 +164,6 @@ t_std_error nas_lag_set_mac(hal_ifindex_t index,const char *lag_mac);
 t_std_error nas_lag_set_admin_status(hal_ifindex_t index, bool enable);
 t_std_error nas_lag_block_port(nas_lag_master_info_t  *p_lag_info ,hal_ifindex_t slave_ifindex,bool block_state);
 t_std_error nas_lag_get_port_mode(hal_ifindex_t slave_ifindex,bool& block_state);
-t_std_error nas_lag_get_admin_status(hal_ifindex_t index, bool enable);
-t_std_error nas_lag_get_oper_status(hal_ifindex_t index, bool enable);
 hal_ifindex_t nas_get_master_idx(hal_ifindex_t ifindex);
 void nas_cps_handle_mac_set (const char *lag_name, hal_ifindex_t lag_index);
 

--- a/scripts/bin/cps_config_lag.py
+++ b/scripts/bin/cps_config_lag.py
@@ -17,9 +17,7 @@ import sys
 import getopt
 import cps
 import cps_object
-import cps_utils
 import nas_ut_framework as nas_ut
-import nas_os_utils
 
 intf_rpc_key_id = 'dell-base-if-cmn/set-interface'
 intf_rpc_op_attr_id = 'dell-base-if-cmn/set-interface/input/operation'
@@ -47,6 +45,7 @@ def nas_lag_op(op, data_dict,commit=True):
         nas_ut.get_cb_method(op)(obj)
     else:
         return (obj, op)
+    return None
 
 
 def usage():

--- a/src/lag/nas_int_lag_api.cpp
+++ b/src/lag/nas_int_lag_api.cpp
@@ -496,7 +496,7 @@ t_std_error nas_lag_set_admin_status(hal_ifindex_t index, bool enable)
 
     if(nas_lag_entry == NULL){
         EV_LOGGING(INTERFACE, ERR, "NAS-LAG",
-                   "Lag intf %d Err in %s", index, __FUNCTION__);
+                   "Lag intf %d Err in set_admin_statue", index);
         return STD_ERR(INTERFACE,FAIL, 0);
     }
 
@@ -508,44 +508,6 @@ t_std_error nas_lag_set_admin_status(hal_ifindex_t index, bool enable)
                    "Lag events publish failure");
         return STD_ERR(INTERFACE, FAIL, 0);
     }
-    return STD_ERR_OK;
-}
-
-t_std_error nas_lag_get_admin_status(hal_ifindex_t index, bool &admin_status)
-{
-    nas_lag_master_info_t *nas_lag_entry = NULL;
-
-    EV_LOGGING(INTERFACE, INFO, "NAS-LAG", "Lag intf %d for set_admin_status",
-               index);
-
-    nas_lag_entry = nas_get_lag_node(index);
-
-    if(nas_lag_entry == NULL){
-        EV_LOGGING(INTERFACE, ERR, "NAS-LAG",
-                   "Lag intf %d Err in %s", index, __FUNCTION__);
-        return STD_ERR(INTERFACE,FAIL, 0);
-    }
-
-    admin_status = nas_lag_entry->admin_status;
-    return STD_ERR_OK;
-}
-
-t_std_error nas_lag_get_oper_status(hal_ifindex_t index, bool &oper_status)
-{
-    nas_lag_master_info_t *nas_lag_entry = NULL;
-
-    EV_LOGGING(INTERFACE, INFO, "NAS-LAG", "Lag intf %d for set_admin_status",
-               index);
-
-    nas_lag_entry = nas_get_lag_node(index);
-
-    if(nas_lag_entry == NULL){
-        EV_LOGGING(INTERFACE, ERR, "NAS-LAG",
-                   "Lag intf %d Err in %s", index, __FUNCTION__);
-        return STD_ERR(INTERFACE,FAIL, 0);
-    }
-
-    oper_status = nas_lag_entry->oper_status;
     return STD_ERR_OK;
 }
 


### PR DESCRIPTION
* Bugfix: Fix issue where LAG interface-state query doesn't apply name filter
* Bugfix: Remove useless imported libraries from cps_config_lag.py
* Bugfix: Remove unneeded function definitions

Signed-off-by: Garrick He <garrick_he@dell.com>