### PR TITLE
Increase service start-up timeout

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-interface], [5.18.0+opx8], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-interface], [5.18.0+opx9], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,12 @@
+opx-nas-interface (5.18.0+opx9) unstable; urgency=medium
+
+  * Update: Increase service start-up time-out
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 30 Aug 2018  11:36:00 -0800
+
 opx-nas-interface (5.18.0+opx8) unstable; urgency=medium
 
-  * Bugfix: opx-vrf-config script so success message isn't display 
+  * Bugfix: opx-vrf-config script so success message isn't display
             multiple times
   * Bugfix: network restart script to address fanned out interface
             issues
@@ -47,7 +53,7 @@ opx-nas-interface (5.18.0+opx4) unstable; urgency=medium
 opx-nas-interface (5.18.0+opx3) unstable; urgency=medium
 
   * Bugfix: SSH connection lost during package installation
-  * Bugfix: Installation hangs due to service start-up order 
+  * Bugfix: Installation hangs due to service start-up order
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 13 Jul 2018 17:17:56 -0800
 
@@ -56,9 +62,9 @@ opx-nas-interface (5.18.0+opx2) unstable; urgency=medium
   * Bugfix: Properly update/publish LAG operation-state information
   * Bugfix: Minor speed improvements
   * Bugfix: cps_config_lag.py script to add memberports properly
- 
+
  -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 09 Jul 2018 17:17:56 -0800
- 
+
 opx-nas-interface (5.18.0+opx1) unstable; urgency=medium
 
   * Bugfix: Sending sequential hwport offset value from port group object to PAS
@@ -74,7 +80,7 @@ opx-nas-interface (5.18.0+opx1) unstable; urgency=medium
  -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 05 Jul 2018 17:17:56 -0800
 
 opx-nas-interface (5.18.0) unstable; urgency=medium
-  
+
   * Update: VLAN interface-state get-handler
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 28 Jun 2018 17:17:56 -0800
@@ -95,11 +101,11 @@ opx-nas-interface (5.17.0) unstable; urgency=medium
             from VLAN
   * Bugfix: FEC is not shown on 100g and 25g interface
   * Bugfix: WFB negotiation is turned off by default
-  * Bugfix: Set NPU port correctly for a member in a bridge for 
+  * Bugfix: Set NPU port correctly for a member in a bridge for
             mapped/unmapped events/
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 18 Jun 2018 17:17:56 -0800
- 
+
 opx-nas-interface (5.10.1+opx15) unstable; urgency=medium
 
   * Bugfix: Fix error when configuring block and unblock LAG memberports in
@@ -113,7 +119,7 @@ opx-nas-interface (5.10.1+opx14) unstable; urgency=medium
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 18 Apr 2018 17:17:56 -0800
 opx-nas-interface (5.10.1+opx13) unstable; urgency=medium
-  
+
   * Bugfix: Crash LAG name doesn't have a number during interface creation
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 12 Apr 2018 17:17:56 -0800
@@ -131,7 +137,7 @@ opx-nas-interface (5.10.1+opx11) unstable; urgency=medium
  -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 23 Mar 2018 15:07:52 -0800
 
 opx-nas-interface (5.10.1+opx10) unstable; urgency=medium
-  
+
   * Bugfix: delete LAG when there are member ports fail.
   * Bugfix: Fix opx-nas-common dependency
 

--- a/scripts/init/opx-create-interface.service
+++ b/scripts/init/opx-create-interface.service
@@ -10,7 +10,7 @@ RemainAfterExit=yes
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/python -u /usr/bin/base_nas_create_interface.py
 ExecStartPost=/bin/sh -c "/bin/sh -c /usr/bin/base_nas_fanout_init.sh && /usr/bin/network_restart.sh"
-TimeoutStartSec=90
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/init/opx-front-panel-ports.service
+++ b/scripts/init/opx-front-panel-ports.service
@@ -8,7 +8,7 @@ OnFailure=service_onfailure@%n.service
 Type=notify
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/python -u /usr/bin/base_nas_front_panel_ports.py
-TimeoutStartSec=90
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/init/opx-monitor-phy-media.service
+++ b/scripts/init/opx-monitor-phy-media.service
@@ -8,7 +8,7 @@ OnFailure=service_onfailure@%n.service
 Type=notify
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/python -u /usr/bin/base_nas_monitor_phy_media.py
-TimeoutStartSec=90
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/init/opx-phy-media-config.service
+++ b/scripts/init/opx-phy-media-config.service
@@ -8,7 +8,7 @@ OnFailure=service_onfailure@%n.service
 Type=notify
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/python -u /usr/bin/base_nas_phy_media_config.py
-TimeoutStartSec=90
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Increase the service start-up timeout to lower the
probability of a service timing out during boot-up.
This change doubles the timeout length.

Signed-off-by: Garrick He <garrick_he@dell.com>