### PR TITLE
Increase service start-up timeout

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-interface], [5.18.0+opx11], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-interface], [5.18.0+opx12], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-nas-interface (5.18.0+opx12) unstable; urgency=medium
+
+  * Update: Increase service start-up time-out
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 17 Sep 2018  11:36:00 -0800
+
 opx-nas-interface (5.18.0+opx11) unstable; urgency=medium
 
   * Update: Service start-up sequence

--- a/scripts/init/opx-create-interface.service
+++ b/scripts/init/opx-create-interface.service
@@ -10,7 +10,7 @@ RemainAfterExit=yes
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/python -u /usr/bin/base_nas_create_interface.py
 ExecStartPost=/bin/sh -c "/bin/sh -c /usr/bin/base_nas_fanout_init.sh && /usr/bin/network_restart.sh"
-TimeoutStartSec=90
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/init/opx-front-panel-ports.service
+++ b/scripts/init/opx-front-panel-ports.service
@@ -8,7 +8,7 @@ OnFailure=service_onfailure@%n.service
 Type=notify
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/python -u /usr/bin/base_nas_front_panel_ports.py
-TimeoutStartSec=90
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/init/opx-monitor-phy-media.service
+++ b/scripts/init/opx-monitor-phy-media.service
@@ -8,7 +8,7 @@ OnFailure=service_onfailure@%n.service
 Type=notify
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/python -u /usr/bin/base_nas_monitor_phy_media.py
-TimeoutStartSec=90
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/init/opx-phy-media-config.service
+++ b/scripts/init/opx-phy-media-config.service
@@ -8,7 +8,7 @@ OnFailure=service_onfailure@%n.service
 Type=notify
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/python -u /usr/bin/base_nas_phy_media_config.py
-TimeoutStartSec=90
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Increase the service start-up timeout to lower the
probability of a service timing out during boot-up.
This change doubles the timeout length.

Signed-off-by: Garrick He <garrick_he@dell.com>