### PR TITLE
Fix: Service start-up sequence

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-interface], [5.18.0+opx10], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-interface], [5.18.0+opx11], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-nas-interface (5.18.0+opx11) unstable; urgency=medium
+
+  * Update: Service start-up sequence
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 14 Sep 2018 11:41:56 -0800
+
 opx-nas-interface (5.18.0+opx10) unstable; urgency=medium
 
   * Bugfix: Reverted the earlier change in opx-phy-media-config.service
@@ -12,7 +18,7 @@ opx-nas-interface (5.18.0+opx9) unstable; urgency=medium
 
 opx-nas-interface (5.18.0+opx8) unstable; urgency=medium
 
-  * Bugfix: opx-vrf-config script so success message isn't display 
+  * Bugfix: opx-vrf-config script so success message isn't display
             multiple times
   * Bugfix: network restart script to address fanned out interface
             issues
@@ -59,7 +65,7 @@ opx-nas-interface (5.18.0+opx4) unstable; urgency=medium
 opx-nas-interface (5.18.0+opx3) unstable; urgency=medium
 
   * Bugfix: SSH connection lost during package installation
-  * Bugfix: Installation hangs due to service start-up order 
+  * Bugfix: Installation hangs due to service start-up order
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 13 Jul 2018 17:17:56 -0800
 
@@ -68,9 +74,9 @@ opx-nas-interface (5.18.0+opx2) unstable; urgency=medium
   * Bugfix: Properly update/publish LAG operation-state information
   * Bugfix: Minor speed improvements
   * Bugfix: cps_config_lag.py script to add memberports properly
- 
+
  -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 09 Jul 2018 17:17:56 -0800
- 
+
 opx-nas-interface (5.18.0+opx1) unstable; urgency=medium
 
   * Bugfix: Sending sequential hwport offset value from port group object to PAS
@@ -86,7 +92,7 @@ opx-nas-interface (5.18.0+opx1) unstable; urgency=medium
  -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 05 Jul 2018 17:17:56 -0800
 
 opx-nas-interface (5.18.0) unstable; urgency=medium
-  
+
   * Update: VLAN interface-state get-handler
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 28 Jun 2018 17:17:56 -0800
@@ -107,11 +113,11 @@ opx-nas-interface (5.17.0) unstable; urgency=medium
             from VLAN
   * Bugfix: FEC is not shown on 100g and 25g interface
   * Bugfix: WFB negotiation is turned off by default
-  * Bugfix: Set NPU port correctly for a member in a bridge for 
+  * Bugfix: Set NPU port correctly for a member in a bridge for
             mapped/unmapped events/
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 18 Jun 2018 17:17:56 -0800
- 
+
 opx-nas-interface (5.10.1+opx15) unstable; urgency=medium
 
   * Bugfix: Fix error when configuring block and unblock LAG memberports in
@@ -125,7 +131,7 @@ opx-nas-interface (5.10.1+opx14) unstable; urgency=medium
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 18 Apr 2018 17:17:56 -0800
 opx-nas-interface (5.10.1+opx13) unstable; urgency=medium
-  
+
   * Bugfix: Crash LAG name doesn't have a number during interface creation
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 12 Apr 2018 17:17:56 -0800
@@ -143,7 +149,7 @@ opx-nas-interface (5.10.1+opx11) unstable; urgency=medium
  -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 23 Mar 2018 15:07:52 -0800
 
 opx-nas-interface (5.10.1+opx10) unstable; urgency=medium
-  
+
   * Bugfix: delete LAG when there are member ports fail.
   * Bugfix: Fix opx-nas-common dependency
 

--- a/scripts/init/opx-front-panel-ports.service
+++ b/scripts/init/opx-front-panel-ports.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Front panel port object access handler
-After=opx-cps.service opx-nas.service
-Requires=opx-cps.service opx-nas.service
+After=opx-cps.service opx-nas.service opx-pas.service opx-phy-media-config.service
+Requires=opx-cps.service opx-nas.service opx-pas.service opx-phy-media-config.service
 OnFailure=service_onfailure@%n.service
 
 [Service]

--- a/scripts/init/opx-monitor-phy-media.service
+++ b/scripts/init/opx-monitor-phy-media.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Physical media event handler
-After=opx-cps.service opx-create-interface.service
-Requires=opx-cps.service opx-create-interface.service
+After=opx-cps.service opx-front-panel-ports.service
+Requires=opx-cps.service opx-front-panel-ports.service
 OnFailure=service_onfailure@%n.service
 
 [Service]

--- a/scripts/init/opx-phy-media-config.service
+++ b/scripts/init/opx-phy-media-config.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Physical media configuration function provider
-After=opx-cps.service opx-create-interface.service
-Requires=opx-cps.service opx-create-interface.service
+After=opx-cps.service
+Requires=opx-cps.service
 OnFailure=service_onfailure@%n.service
 
 [Service]


### PR DESCRIPTION
This fix ensures that opx-nas services are starting up in the
proper dependency order so interface settings are properly applied.

Fixes #52

Signed-off-by: Garrick He <garrick_he@dell.com>