### PR TITLE
fix: Interface settings not programmed into NPU

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-interface], [5.20.3+opx4], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-interface], [5.20.3+opx5], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,13 @@
-opx-nas-interface (5.20.3+opx3) unstable; urgency=medium
+opx-nas-interface (5.20.3+opx5) unstable; urgency=medium
+
+  * Bugfix: Bring down all interfaces (excluding system loopback) before Networking
+            service restarts to ensure all interface settings in /etc/network/interfaces
+            are properly programmed into the NPU via NetLink messages
+  * Update: Correct debian/changelog version number
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 27 Nov 2018  11:36:00 -0800
+
+opx-nas-interface (5.20.3+opx4) unstable; urgency=medium
 
   * Bugfix: Fix opx-create-interface service so interface settings get properly
             applied

--- a/scripts/bin/network_restart.sh
+++ b/scripts/bin/network_restart.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
-# Restart networking service without shuting down
-# interfaces that are already up
+# Bring down all interfaces (except system loopback) before restarting Networking service
+# to ensure that all interface settings gets programmed into the NPU
+
+/sbin/ifdown -a --exclude=lo
 service networking restart


### PR DESCRIPTION
* Bugfix: Bring down all interfaces (excluding system loopback) before Networking
          service restarts to ensure all interface settings in /etc/network/interfaces
          are properly programmed into the NPU via NetLink messages
* Update: Correct debian/changelog version number

Signed-off-by: Garrick He <garrick_he@dell.com>